### PR TITLE
Camb_sources - including dN/dz in the window function

### DIFF
--- a/modules.f90
+++ b/modules.f90
@@ -3948,7 +3948,7 @@
                     end if
                 end do
 
-                !comoving_density_ev is d log(a^3 n_s)/d eta * window
+                !comoving_density_ev is d log(a^3 n_s)/d eta
                 call spline(TimeSteps%points(jstart),RedWin%comoving_density_ev(jstart),ninterp,spl_large,spl_large,tmp)
                 call spline_deriv(TimeSteps%points(jstart),RedWin%comoving_density_ev(jstart),tmp,tmp2(jstart),ninterp)
                 do ix = jstart, TimeSteps%npoints

--- a/modules.f90
+++ b/modules.f90
@@ -84,7 +84,10 @@
 
     dz = z-Win%Redshift
     winamp =  exp(-(dz/Win%sigma)**2/2)
-    count_obs_window_z =winamp/Win%sigma/root2pi
+    count_obs_window_z =winamp/Win%sigma/root2pi*counts_background_z(Win, z)
+	!The observational window function comes multiplied by dN/dz
+	!in effect dN/dz is a probability distribution function inside the observational window function. 
+	!for narrow windows this is irrelevant
     !!!
     !         winamp =  z**3*exp(-(z/3.35821)**13)/20
     !         count_obs_window_z = winamp*20/28.49261877
@@ -98,9 +101,10 @@
     real(dl), intent(in) :: z
     real(dl) counts_background_z, winamp
 
-    counts_background_z = count_obs_window_z(Win, z, winamp)
-    !This is the special case where you observe all of the sources
-
+    counts_background_z = 1
+	!A specific redshift dependence of the background counts needs to be input here 
+    !In this case there is a contanst distribution of sources with redshift (but unphysical)
+	
     end function counts_background_z
 
     function Window_f_a(Win, a, winamp)


### PR DESCRIPTION
Hi Antony

I think we should split clearly the observational window function, let's say gaussian, from the selection function, or dN/dz. Then it becomes clearer how the evolution bias is computed. In your paper I think this is implicit. For very narrow window function this is irrelevant but for a window large enough it may actually distort the gaussian, i.e., one end contributes more for the Cl than other. An example can be quasars that after redshift may have a sharp decay. Maybe the code takes care of this already if we edit count_obs_window_z. I think the way I propose is more intuitive. What do you think?

Zé
