### PR TITLE
a global set params functions

### DIFF
--- a/pycamb/camb/__init__.py
+++ b/pycamb/camb/__init__.py
@@ -11,7 +11,7 @@ __version__ = "0.1.0"
 
 from .baseconfig import dll_import
 from .camb import CAMBdata, MatterTransferData, get_results, get_transfer_functions, get_background, \
-    get_age, get_zre_from_tau, set_z_outputs, set_feedback_level
+    get_age, get_zre_from_tau, set_z_outputs, set_feedback_level, set_params
 from . import model
 from . import initialpower
 from . import reionization


### PR DESCRIPTION
A first attempt at a global `set_params` type function, e.g. so you can do 

    cp = camb.set_params(ns=1, omch2=0.1, ALens=1.2, lmax=2000)

and under the hood what happens is:

    cp = model.CAMBparams()
    cp.set_cosmology(omch2=0.1)
    cp.set_for_lmax(lmax=2000)
    cp.InitPower.set_params(ns=1)
    lensing.ALens.value = 1.2

It works with `inspect` so future changes to all the under the hood functions shouldn't need too much, if any, work. I only did ALens as a global parameter as an example, others can probably be added. 