### PR TITLE
Allow specifying theta instead of H0

### DIFF
--- a/pycamb/camb/camb.py
+++ b/pycamb/camb/camb.py
@@ -915,17 +915,21 @@ def get_transfer_functions(params):
     return res
 
 
-def get_background(params):
+def get_background(params,no_thermo=False):
     """
     Calculate background cosmology for specified parameters and return :class:`CAMBdata`, ready to get derived
      parameters and use background functions like angular_diameter_distance.
 
     :param params: :class:`.model.CAMBparams` instance
+    :params no_thermo: Use calc_background_no_thermo instead
     :return: :class:`CAMBdata` instance
     """
 
     res = CAMBdata()
-    res.calc_background(params)
+    if no_thermo:
+        res.calc_background_no_thermo(params)
+    else:
+        res.calc_background(params)
     return res
 
 

--- a/pycamb/camb/model.py
+++ b/pycamb/camb/model.py
@@ -317,6 +317,14 @@ class CAMBparams(CAMB_Structure):
         """
 
 
+        if YHe is None:
+            # use BBN prediction
+            self.set_bbn_helium(ombh2, nnu - standard_neutrino_neff, tau_neutron)
+            YHe = self.YHe
+        else:
+            self.YHe = YHe
+
+
         if cosmomc_theta is not None:
             kw=locals(); [kw.pop(x) for x in ['self','H0','cosmomc_theta']]
 
@@ -332,7 +340,7 @@ class CAMBparams(CAMB_Structure):
 
             def f(H0):
                 self.set_cosmology(H0=H0,**kw)
-                return camb.get_background(self).cosmomc_theta() - cosmomc_theta
+                return camb.get_background(self,no_thermo=True).cosmomc_theta() - cosmomc_theta
 
             self.H0 = brentq(f,10,100,rtol=1e-4)
         else:
@@ -340,11 +348,7 @@ class CAMBparams(CAMB_Structure):
 
 
 
-        if YHe is None:
-            # use BBN prediction
-            self.set_bbn_helium(ombh2, nnu - standard_neutrino_neff, tau_neutron)
-        else:
-            self.YHe = YHe
+
         self.TCMB = TCMB
         fac = (self.H0 / 100.0) ** 2
         self.omegab = ombh2 / fac


### PR DESCRIPTION
Uses `brentq` to solve for the equivalent `H0`, so you can do e.g. `camb.set_params(cosmomc_theta=0.0104,H0=None)`. 

This could possibly be optimized for speed more. Right now 3/4 of the time is spent inside of `calc_background_no_thermo` and 1/4 inside `cosmomc_theta`, I'm not sure how much of the stuff in `calc_background_no_thermo` is necessary. 