### PR TITLE
make scipy fully optional dependency

### DIFF
--- a/pycamb/camb/baseconfig.py
+++ b/pycamb/camb/baseconfig.py
@@ -107,3 +107,15 @@ class CAMB_Structure(Structure):
                 else:
                     s += field_name + ' = ' + str(obj) + '\n'
         return s
+
+
+try:
+    import scipy
+except ImportError:
+    has_scipy = False
+else:
+    has_scipy = True
+
+def needs_scipy():
+    if not has_scipy:
+        raise Exception("You need scipy installed to use this functionality of CAMB.")

--- a/pycamb/camb/bbn.py
+++ b/pycamb/camb/bbn.py
@@ -5,10 +5,7 @@
 import numpy as np
 import os
 import io
-from .baseconfig import mock_load
-
-if not mock_load:
-    from scipy.interpolate import RectBivariateSpline
+from .baseconfig import mock_load, needs_scipy
 
 # Various useful constants
 hbar = 1.05457e-34
@@ -103,6 +100,9 @@ class BBN_table_interpolator(BBNPredictor):
             grid[ombh2s.index(table[i, 0]), deltans.index(table[i, 1])] = table[i, 2]
             dh_grid[ombh2s.index(table[i, 0]), deltans.index(table[i, 1])] = table[i, 3]
 
+        needs_scipy()
+        from scipy.integrate import RectBivariateSpline
+        
         self.interpolator_Yp = RectBivariateSpline(ombh2s, deltans, grid)
         self.interpolator_DH = RectBivariateSpline(ombh2s, deltans, dh_grid)
 

--- a/pycamb/camb/correlations.py
+++ b/pycamb/camb/correlations.py
@@ -14,6 +14,8 @@ A. Lewis December 2016
 import numpy as np
 import os
 
+from .baseconfig import needs_scipy
+
 try:
     from .baseconfig import camblib
     from numpy.ctypeslib import ndpointer
@@ -28,9 +30,7 @@ except:
     # Fortran version is much faster than current np.polynomial
     gauss_legendre = None
 
-if not os.environ.get('READTHEDOCS', None):
-    from scipy.special import lpn as legendreP
-else:
+if os.environ.get('READTHEDOCS', None):
     np.pi = 3.1415927  # needed to get docs right for np.pi/32 default argument
 
 
@@ -66,6 +66,10 @@ def legendre_funcs(lmax, x, m=[0, 2], lfacs=None, lfacs2=None, lrootfacs=None):
     :param lrootfacs: optional pre-computed sqrt(lfacs*lfacs2) array
     :return: (P,dP),(d11,dm11), (d20, d22, d2m2) as requested, where P starts at L=0, but spin functions start at L=Lmin
     """
+
+    needs_scipy()
+    from scipy.special import lpn as legendreP
+    
     allP, alldP = legendreP(lmax, x)
     # Polarization functions all start at L=2
     fac1 = 1 - x
@@ -211,6 +215,10 @@ def lensing_correlations(clpp, xvals, lmax=None):
     :param lmax: optional maximum L to use from the cls arrays
     :return: sigmasq, Cg2
     """
+    
+    needs_scipy()
+    from scipy.special import lpn as legendreP
+
     if lmax is None: lmax = clpp.shape[0] - 1
     ls = np.arange(1, lmax + 1, dtype=np.float64)
     cldd = clpp[1:] / (ls * (ls + 1))

--- a/pycamb/camb/emission_angle.py
+++ b/pycamb/camb/emission_angle.py
@@ -7,6 +7,7 @@ Corrections to T and E are negligible, and not calculated. The result for BB inc
 from reionization, but this can optionally be turned off.
 """
 
+from .baseconfig import needs_scipy
 from . import camb, model
 import numpy as np
 from .bispectrum import threej
@@ -48,6 +49,7 @@ def get_emission_angle_powers(camb_background, PK, chi_source, lmax=3000, acc=1,
     :return: a UnivariateSpline object containing L(L+1) C_L
     """
 
+    needs_scipy()
     from scipy.interpolate import UnivariateSpline
 
     assert (isinstance(camb_background, camb.CAMBdata) and not camb_background.Params.omegak)
@@ -80,6 +82,7 @@ def get_emission_delay_BB(params, kmax=100, lmax=3000, non_linear=True, CMB_unit
     :return: C_L^{BB}, the L sample values and corresponding rotation power
     """
 
+    needs_scipy()
     from scipy.interpolate import UnivariateSpline
 
     assert (not params.omegak)

--- a/pycamb/camb/model.py
+++ b/pycamb/camb/model.py
@@ -1,4 +1,4 @@
-from .baseconfig import camblib, CAMB_Structure, CAMBError, CAMBParamRangeError, dll_import
+from .baseconfig import camblib, CAMB_Structure, CAMBError, CAMBParamRangeError, dll_import, needs_scipy
 from ctypes import c_bool, c_int, c_double, c_float, byref, POINTER
 from . import reionization as ion
 from . import recombination as recomb
@@ -349,10 +349,8 @@ class CAMBparams(CAMB_Structure):
             if H0 is not None:
                 raise CAMBError('Set H0=None when setting cosmomc_theta.')
 
-            try:
-                from scipy.optimize import brentq
-            except ImportError:
-                raise CAMBError('You need SciPy to set cosmomc_theta.')
+            needs_scipy()
+            from scipy.optimize import brentq
 
             from . import camb
 

--- a/pycamb/camb/postborn.py
+++ b/pycamb/camb/postborn.py
@@ -1,8 +1,9 @@
 from . import camb, model
 import numpy as np
-from .baseconfig import mock_load
+from .baseconfig import mock_load, needs_scipy
 
 if not mock_load:
+    needs_scipy()
     from scipy.interpolate import RectBivariateSpline, UnivariateSpline
 
 

--- a/pycamb/requirements.txt
+++ b/pycamb/requirements.txt
@@ -3,4 +3,3 @@ matplotlib
 six
 mock
 sympy>=1.0
-scipy


### PR DESCRIPTION
I made some changes to turn scipy into a fully optional dependency. Not sure if you want this as it is slightly wordy every time you need to use scipy. At the same time, I think its nice as scipy is not totally trivial to install on all systems and a lot of pycamb works without it. 

Right now this conflicts since its branched off the Aug version, but if you like this I can rebase it on master. 