### PR TITLE
Small update to include HMcode 2015 and 2016 versions separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Release/
 *egg*
 build
 inspectionProfiles
+camb

--- a/params.ini
+++ b/params.ini
@@ -248,9 +248,14 @@ accurate_massive_neutrino_transfers = F
 do_late_rad_truncation   = T
 
 #Which version of Halofit approximation to use (default currently Takahashi):
-#1. original, 2. Bird et al. update, 3. (1) plus fudge from http://www.roe.ac.uk/~jap/haloes/, 4. Takahashi
-#5. Use HMcode (Mead et al. 2015,2016), 6. Use halomodel (a standard calculation, without the accuracy tweaks of HMcode)
-#7. PKequal  (arXiv:0810.0190, arXiv:1601.07230)
+#1. Original Smith et al. (2003; arXiv:astro-ph/0207664) HALOFIT
+#2. Bird et al. (arXiv:1109.4416) updated HALOFIT
+#3. Original plus fudge from http://www.roe.ac.uk/~jap/haloes/,
+#4. Takahashi (2012; arXiv:1208.2701) HALOFIT update
+#5. HMcode (Mead et al. 2016; arXiv 1602.02154)
+#6. A standard (inaccurate) halo model power spectrum calcultion
+#7. PKequal (Casarini et al. arXiv:0810.0190, arXiv:1601.07230)
+#8. HMcode (Mead et al. 2015; arXiv 1505.07833)
 halofit_version= 
 
 #Computation parameters


### PR DESCRIPTION
Some work that people have been doing recently has shown some small differences in cosmological parameter constraints from weak lensing when using the 2015 or 2016 versions of HMcode. This pull requests adds an HALOFIT_version=8 which maps to the 2015 version of HMcode. Otherwise nothing has changed. HALOFIT_version=5 maps to the 2016 version of HMcode as before.