### PR TITLE
Conversions of various MpiStops to GlobalErrors

### DIFF
--- a/camb/results.py
+++ b/camb/results.py
@@ -1137,6 +1137,7 @@ class CAMBdata(F2003Class):
             times = np.asarray(eta, dtype=np.float64)
         redshifts = np.empty(times.shape)
         self.f_RedshiftAtTimeArr(redshifts, times, byref(c_int(times.shape[0])))
+        config.check_global_error('redshift_at_conformal_time')
         if np.isscalar(eta):
             return redshifts[0]
         else:

--- a/camb/results.py
+++ b/camb/results.py
@@ -749,6 +749,9 @@ class CAMBdata(F2003Class):
         if not have_power_spectra:
             self.calc_power_spectra(params)
 
+        if not npoints >= 2:
+            raise CAMBError('Need at least two points in get_matter_power_spectrum')
+
         assert self.Params.WantTransfer
         if self.Params.Transfer.kmax < maxkh:
             logging.warning("get_matter_power_spectrum using larger k_max than input parameter Transfer.kmax")

--- a/fortran/results.f90
+++ b/fortran/results.f90
@@ -780,7 +780,8 @@
     integer i
     real(dl) om
 
-    if (this%ThermoData%ScaleFactorAtTime%n==0) call MpiStop('RedshiftAtTimeArr: background history not calculated')
+    if (this%ThermoData%ScaleFactorAtTime%n==0) call GlobalError('RedshiftAtTimeArr: background history not calculated', error_unsupported_params)
+    if (global_error_flag/=0) return
     !$OMP PARALLEL DO DEFAULT(SHARED), private(om, i)
     do i=1, n
         if (tau(i) < this%ThermoData%tauminn*1.1) then

--- a/fortran/results.f90
+++ b/fortran/results.f90
@@ -2228,9 +2228,18 @@
 
     !Sources
     if (.not. State%CP%Want_CMB .and. State%CP%WantCls) then
-        if (State%num_redshiftwindows==0) call MpiStop('Want_CMB=false, but not redshift windows either')
-        call TimeSteps%Add_delta(this%tau_start_redshiftwindows, State%tau0, dtau0)
+        if (State%num_redshiftwindows==0) then
+            call GlobalError('Want_CMB=false, but not redshift windows either', error_unsupported_params)
+        else
+            call TimeSteps%Add_delta(this%tau_start_redshiftwindows, State%tau0, dtau0)
+        endif
     end if
+
+    if (global_error_flag/=0) then
+        return
+    end if
+
+
 
     !Create arrays out of the region information.
     call TimeSteps%GetArray()

--- a/fortran/results.f90
+++ b/fortran/results.f90
@@ -346,7 +346,7 @@
         this%ThermoData%HasThermoData = .false.
         if (this%CP%Num_Nu_Massive /= sum(this%CP%Nu_mass_numbers(1:this%CP%Nu_mass_eigenstates))) then
             if (sum(this%CP%Nu_mass_numbers(1:this%CP%Nu_mass_eigenstates))/=0) &
-                call MpiStop('Num_Nu_Massive is not sum of Nu_mass_numbers')
+                call GlobalError('Num_Nu_Massive is not sum of Nu_mass_numbers', error_unsupported_params)
         end if
         if (this%CP%Omnuh2 < 1.e-7_dl) this%CP%Omnuh2 = 0
         if (this%CP%Omnuh2==0 .and. this%CP%Num_Nu_Massive /=0) then
@@ -361,7 +361,7 @@
 
         nu_massless_degeneracy = this%CP%Num_Nu_massless !N_eff for massless neutrinos
         if (this%CP%Num_nu_massive > 0) then
-            if (this%CP%Nu_mass_eigenstates==0) call MpiStop('Have Num_nu_massive>0 but no nu_mass_eigenstates')
+            if (this%CP%Nu_mass_eigenstates==0) call GlobalError('Have Num_nu_massive>0 but no nu_mass_eigenstates', error_unsupported_params)
             if (this%CP%Nu_mass_eigenstates==1 .and. this%CP%Nu_mass_numbers(1)==0) &
                 this%CP%Nu_mass_numbers(1) = this%CP%Num_Nu_Massive
             if (all(this%CP%Nu_mass_numbers(1:this%CP%Nu_mass_eigenstates)==0)) this%CP%Nu_mass_numbers=1 !just assume one for all
@@ -375,10 +375,16 @@
                     this%CP%Nu_mass_numbers(1:this%CP%Nu_mass_eigenstates)*neff_i
             end if
             if (abs(sum(this%CP%Nu_mass_fractions(1:this%CP%Nu_mass_eigenstates))-1) > 1e-4) &
-                call MpiStop('Nu_mass_fractions do not add up to 1')
+            call GlobalError('Nu_mass_fractions do not add up to 1', error_unsupported_params)
         else
             this%CP%Nu_mass_eigenstates = 0
         end if
+
+        if (global_error_flag/=0) then
+            if (present(error)) error = global_error_flag
+            return
+        end if
+
 
         call This%ThermoData%ScaleFactorAtTime%Clear()
 

--- a/fortran/subroutines.f90
+++ b/fortran/subroutines.f90
@@ -170,6 +170,7 @@
     subroutine dverk (EV,n, fcn, x, y, xend, tol, ind, c, nw, w)
     use Precision
     use MpiUtils
+    use Config, only : GlobalError, error_evolution
     integer n, ind, nw, k
     real(dl) x, y(n), xend, tol, c(*), w(nw,9), temp
     real EV !it isn't, but as long as it maintains it as a pointer we are OK
@@ -920,7 +921,7 @@
     !
 
     write (*,*) 'Error in dverk, x =',x, 'xend=', xend
-    call MpiStop('DVERK error')
+    call GlobalError('DVERK error', error_evolution)
     !
     end subroutine dverk
 


### PR DESCRIPTION
Hi Antony,

These changes convert several cases where an MpiStop can be triggered from the python level into GlobalError calls, so that it's less likely either that people exploring in python will have their session killed. 

I've also done the same to the dverk call, which can occasionally be triggered in some models during long MCMC runs.

Cheers,
Joe