### PR TITLE
Expose HMCode baryon parameters

### DIFF
--- a/camb/nonlinear.py
+++ b/camb/nonlinear.py
@@ -32,7 +32,9 @@ class Halofit(NonLinearModel):
     Various specific approximate non-linear correction models based on HaloFit.
     """
     _fields_ = [
-        ("halofit_version", c_int, {"names": halofit_version_names, "start": 1})
+        ("halofit_version", c_int, {"names": halofit_version_names, "start": 1}),
+        ("HMCode_A_baryon", c_double, "HMCode parameter A_baryon"),
+        ("HMCode_eta_baryon", c_double, "HMCode parameter eta_baryon"),
     ]
 
     _fortran_class_module_ = 'NonLinear'
@@ -41,7 +43,7 @@ class Halofit(NonLinearModel):
     def get_halofit_version(self):
         return self.halofit_version
 
-    def set_params(self, halofit_version=halofit_default):
+    def set_params(self, halofit_version=halofit_default, HMCode_A_baryon=3.13, HMCode_eta_baryon=0.603):
         """
         Set the halofit model for non-linear corrections.
 
@@ -55,9 +57,12 @@ class Halofit(NonLinearModel):
             - halomodel: basic halomodel
             - casarini: PKequal `arXiv:0810.0190 <https://arxiv.org/abs/0810.0190>`_, `arXiv:1601.07230 <https://arxiv.org/abs/1601.07230>`_
             - mead2015: original 2015 version of HMCode `arXiv:1505.07833 <https://arxiv.org/abs/1505.07833>`_
-
+        :param HMCode_A_baryon: HMCode parameter A_baryon. Default 3.13.
+        :param HMCode_eta_baryon: HMCode parameter eta_baryon. Default 0.603.
         """
         self.halofit_version = halofit_version
+        self.HMCode_A_baryon = HMCode_A_baryon
+        self.HMCode_eta_baryon = HMCode_eta_baryon
 
 
 @fortran_class

--- a/fortran/halofit.f90
+++ b/fortran/halofit.f90
@@ -58,6 +58,8 @@
 
     type, extends(TNonLinearModel) :: THalofit
         integer :: halofit_version = halofit_default
+        !!TT - These are the baryon parameters of HMCode
+        real(dl) :: HMCode_A_baryon, HMCode_eta_baryon
         !!AM - Added these types for HMcode
         integer, private :: imead !!AM - added these for HMcode, need to be visible to all subroutines and functions
         real(dl), private :: om_m,om_v,fnu,omm0, acur, w_hf, wa_hf
@@ -440,6 +442,10 @@
     !!AM - Translate from CAMB variables to my variables
     nz=CAMB_PK%num_z
     nk=CAMB_PK%num_k
+
+    !!TT - Assign baryon parameters
+    cosi%A_baryon = this%HMCode_A_baryon
+    cosi%eta_baryon = this%HMCode_eta_baryon
 
     !!AM - Assign cosmological parameters for the halo model calculation
     CALL assign_HM_cosmology(State,cosi)

--- a/fortran/halofit.f90
+++ b/fortran/halofit.f90
@@ -59,7 +59,8 @@
     type, extends(TNonLinearModel) :: THalofit
         integer :: halofit_version = halofit_default
         !!TT - These are the baryon parameters of HMCode
-        real(dl) :: HMCode_A_baryon, HMCode_eta_baryon
+        real(dl) :: HMCode_A_baryon=3.13
+        real(dl) :: HMCode_eta_baryon=0.603
         !!AM - Added these types for HMcode
         integer, private :: imead !!AM - added these for HMcode, need to be visible to all subroutines and functions
         real(dl), private :: om_m,om_v,fnu,omm0, acur, w_hf, wa_hf


### PR DESCRIPTION
This PR exposes the HMCode baryon parameters `A_baryon` and `eta_baryon` in the python interface:
```python
pars.NonLinearModel.set_params(halofit_version='mead', 
                               HMCode_A_baryon=2.5, HMCode_eta_baryon=0.8)
```
The two parameters default to the values in `HM_cosmology`, i.e., `A_baryon=3.13` and `eta_baryon=0.603`, so that the default behaviour remains unchanged.