### PR TITLE
fixed mac ifort compile issue

### DIFF
--- a/camb/symbolic.py
+++ b/camb/symbolic.py
@@ -706,7 +706,7 @@ def get_default_compiler():
         import platform
         _default_compiler = 'ifort'
         if platform.system() == 'Darwin':
-            _default_flags = "-dynamiclib -fpic -O1 -W0 -WB"
+            _default_flags = "-dynamiclib -O1 -W0 -WB" #-fpic
         else:
             _default_flags = "-shared -fpic -O1 -W0 -WB"
     # _default_flags="-shared -fPIC -g -fbounds-check -fbacktrace -ffpe-trap=invalid,overflow,zero",

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -59,7 +59,7 @@ FFLAGS = -fp-model precise -W0 -WB $(COMMON_FFLAGS)
 DEBUGFLAGS =  -g -check all -check noarg_temp_created -traceback -fpe0 $(COMMON_FFLAGS)
 
 ifeq ($(shell uname -s),Darwin)
-SFFLAGS = -dynamiclib -fpic
+SFFLAGS = -dynamiclib #-fpic
 else
 SFFLAGS = -shared -fpic
 endif
@@ -95,7 +95,12 @@ COMMON_FFLAGS = -MMD -cpp -ffree-line-length-none -fmax-errors=4 -fopenmp
 # Using -ffast-math causes differences between Debug and Release configurations.
 FFLAGS = -O3 $(COMMON_FFLAGS)
 DEBUGFLAGS = -g -fbacktrace -ffpe-trap=invalid,overflow,zero -fbounds-check $(COMMON_FFLAGS)
-SFFLAGS =  -shared -fPIC
+ifeq ($(shell uname -s),Darwin)
+SFFLAGS = -dynamiclib #-fpic
+else
+SFFLAGS = -shared -fpic
+endif
+#SFFLAGS =  -shared -fPIC
 MODOUT =  -J$(OUTPUT_DIR)
 SMODOUT = -J$(DLL_DIR)
 


### PR DESCRIPTION
I believe the changes I have made in this branch resolve the mac ifort compile issues. I removed the '-fpic' flag since it is not needed if the '-dynamiclib' flag is used. Further, I also made the following changes to the Makefile_compiler file in forutils, but could not push them:

Under I believe line 34 [i.e. ifeq ($(shell test $(ifortVer_major) -gt 15; echo $$?),0)] in the most recent version, I added:

  ifeq ($(shell uname -s),Darwin)
  F90COMMONFLAGS ?= -fpp -W0 -WB -qopenmp
  else
  F90COMMONFLAGS ?= -fpp -W0 -WB -fpic -qopenmp
  endif