### PR TITLE
this fixes issue 58: an array out of bound error in equations.f90 and division by zero in model.f90

### DIFF
--- a/fortran/equations.f90
+++ b/fortran/equations.f90
@@ -369,14 +369,15 @@
         else if (next_switch == tau_switch_nu_massless) then
             !Mass starts to become important, start evolving next momentum mode
             do nu_i = 1, CP%Nu_mass_eigenstates
-                if (EV%nq(nu_i) /= State%NuPerturbations%nqmax .and. &
-                    next_switch == nu_tau_notmassless(next_nu_nq(EV%nq(nu_i)),nu_i)) then
-                    EVOut%nq(nu_i) = next_nu_nq(EV%nq(nu_i))
-                    call SetupScalarArrayIndices(EVout)
-                    call CopyScalarVariableArray(y,yout, EV, EVout)
-                    EV=EVout
-                    y=yout
-                    exit
+                if (EV%nq(nu_i) /= State%NuPerturbations%nqmax) then
+                    if (next_switch == nu_tau_notmassless(next_nu_nq(EV%nq(nu_i)),nu_i)) then
+                        EVOut%nq(nu_i) = next_nu_nq(EV%nq(nu_i))
+                        call SetupScalarArrayIndices(EVout)
+                        call CopyScalarVariableArray(y,yout, EV, EVout)
+                        EV=EVout
+                        y=yout
+                        exit
+                    endif
                 end if
             end do
         else if (next_switch == tau_switch_nu_nonrel) then

--- a/fortran/model.f90
+++ b/fortran/model.f90
@@ -278,7 +278,7 @@
             else if (neutrino_hierarchy == neutrino_hierarchy_inverted) then
                 if (mnu > sqrt(delta_mnu31)+sqrt(delta_mnu31+delta_mnu21) + 1e-4_dl ) then
                     !Valid case, two eigenstates
-                    m1=Newton_Raphson2(sqrt(delta_mnu31), mnu, sum_mnu_for_m1, mnu, -1._dl)
+                    m1=Newton_Raphson2(sqrt(delta_mnu31)+1e-6_dl, mnu, sum_mnu_for_m1, mnu, -1._dl)
                     this%Num_Nu_Massive = 3
                 else
                     !Unphysical low mass case: take one (2-degenerate) eigenstate


### PR DESCRIPTION
Added one more layer of if in equations.f90 GaugeInterface_EvolveScal. Added a small number to the lower bound when finding root for the inverted hierarchy case in model.f90 CAMBparams_SetNeutrinoHierarchy.