### PR TITLE
bug in baseconfig.py

### DIFF
--- a/camb/baseconfig.py
+++ b/camb/baseconfig.py
@@ -97,7 +97,7 @@ def set_cl_template_file(cl_template_file=None):
                                             "HighLExtrapTemplate_lenspotentialCls.dat")
     if not osp.exists(template):
         template = osp.abspath(
-            osp.join(BASEDIR, "..", "..", "fortran",
+            osp.join(BASEDIR, "..", "fortran",
                      "HighLExtrapTemplate_lenspotentialCls.dat"))
     template = template.encode("latin-1")
     func = camblib.__handles_MOD_set_cls_template


### PR DESCRIPTION
In the new version of the baseconfig.py file you appear to have introduced a bug. 

osp.join(BASEDIR, "..", "..", "fortran",
                     "HighLExtrapTemplate_lenspotentialCls.dat"))

in the previous versions of camb the above line was looking like this :

osp.join(BASEDIR, "..", "fortran",
                     "HighLExtrapTemplate_lenspotentialCls.dat"))

This make the python wrapper looking in the wrong folder for the HighLExtrapTemplate_lenspotentialCls.dat file.