### PR TITLE
Fix default argument list

### DIFF
--- a/camb/camb.py
+++ b/camb/camb.py
@@ -195,7 +195,7 @@ def get_valid_numerical_params(transfer_only=False, **class_names):
 
     def extract_params(set_func):
         pars = getfullargspec(set_func)
-        for arg, v in zip(pars.args[1:], pars.defaults[1:]):
+        for arg, v in zip(pars.args[1:], pars.defaults):
             if (isinstance(v, numbers.Number) or v is None) and 'version' not in arg:
                 params.add(arg)
 


### PR DESCRIPTION
getfullargspec parses the function argument list prepending `self` to the `args` list. So removing
first item is fine for `args` values but the `ðefault` argument values does not add a default value
for `self`. So there will be a shift by 1 when zipping both.

For cosmology parameters, for instance, the `theta_H0_range` is always skipped, same for sound speed squared *aka* `cs2`.