### PR TITLE
Add default value to function argument

### DIFF
--- a/camb/dark_energy.py
+++ b/camb/dark_energy.py
@@ -111,10 +111,11 @@ class AxionEffectiveFluid(DarkEnergyModel):
     _fortran_class_name_ = 'TAxionEffectiveFluid'
     _fortran_class_module_ = 'DarkEnergyFluid'
 
-    def set_params(self, w_n, om, a_c):
+    def set_params(self, w_n=None, om=None, a_c=None, theta_i=None):
         self.w_n = w_n
         self.om = om
         self.a_c = a_c
+        self.theta_i = theta_i
 
 
 # short names for models that support w/wa


### PR DESCRIPTION
Related to #76 , when parsing function parameters, the `get_valid_numerical_params` function needs
default value for parameters. `theta_i` was also missing (bugfix by @adrien-laposta).