### PR TITLE
Added cosmomc compilation folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ build
 testfiles
 inspectionProfiles
 fortran/camb
+fortran/DebugMPI
+fortran/ReleaseMPI/
 Advisor/
 Inspector/
 .ipynb_checkpoints


### PR DESCRIPTION
When CosmoMC compiles in normal and debug mode it creates these two folders with the compilation files. Added them to the gitignore.