### PR TITLE
Small change to OMP in debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@
 .project
 .pydevproject
 x64/
-Debug/
-Release/
-Releaselib/
 WinDLL/
 *.suo
 *.d
@@ -29,10 +26,16 @@ core
 build
 testfiles
 inspectionProfiles
-fortran/camb
-fortran/DebugMPI
-fortran/ReleaseMPI/
 Advisor/
 Inspector/
 .ipynb_checkpoints
 camb/HighLExtrapTemplate_lenspotentialCls.dat
+
+# compilation products:
+fortran/camb
+Debug/
+Debuglib/
+Release/
+Releaselib/
+DebugMPI/
+ReleaseMPI/

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -133,6 +133,7 @@ FFLAGS += -DFISHER
 endif
 
 DEBUGFLAGS ?= $(FFLAGS)
+DEBUGFLAGS += -DDEBUG
 Debug: FFLAGS = $(DEBUGFLAGS)
 
 include ./Makefile_main

--- a/fortran/config.f90
+++ b/fortran/config.f90
@@ -15,8 +15,13 @@
 
     real(dl) :: DebugParam = 0._dl !not used but read in, useful for parameter-dependent tests
 
+#ifdef DEBUG
+    ! In debug mode default to single thread
+    integer :: ThreadNum = 1
+#else
+    ! If zero assigned automatically to OMP_NUM_THREADS, obviously only used if parallelised
     integer :: ThreadNum = 0
-    !If zero assigned automatically, obviously only used if parallelised
+#endif
 
     logical ::  do_bispectrum  = .false.
     logical, parameter :: hard_bispectrum = .false. ! e.g. warm inflation where delicate cancellations


### PR DESCRIPTION
In debug mode OMP runs single threaded to allow traceback to work inside OMP sections.
Behavior can be overridden by parameter file by specifying explicitly the number of threads to work with.

Small change to gitignore to ignore debug compilation folders.