### PR TITLE
changed default non-linear model to HMcode-2020

### DIFF
--- a/camb/nonlinear.py
+++ b/camb/nonlinear.py
@@ -23,7 +23,7 @@ halofit_mead2016 = 'mead2016'
 halofit_mead2020 = 'mead2020'
 halofit_mead2020_feedback = 'mead2020_feedback'
 
-halofit_default = halofit_mead
+halofit_default = halofit_mead2020
 
 halofit_version_names = {halofit_original          : 1,
                          halofit_bird              : 2,

--- a/fortran/halofit.f90
+++ b/fortran/halofit.f90
@@ -59,7 +59,7 @@
     integer, parameter :: halofit_mead2016=5, halofit_halomodel=6, halofit_mead2015=8, halofit_mead2020=9
     integer, parameter :: halofit_mead2020_feedback=10
     integer, parameter :: halofit_mead=halofit_mead2016 ! AM Kept for backwards compatability
-    integer, parameter :: halofit_default=halofit_mead2016
+    integer, parameter :: halofit_default=halofit_mead2020
 
     logical :: HM_verbose = .false.
 

--- a/inifiles/params.ini
+++ b/inifiles/params.ini
@@ -256,7 +256,7 @@ do_late_rad_truncation   = T
 #8. HMcode (Mead et al. 2015; arXiv:1505.07833)
 #9. HMcode-2020 (Mead et al. 2020; arXiv:2009.01858)
 #10. HMcode-2020 with baryonic feedback (Mead et al. 2020; arXiv:2009.01858)
-halofit_version= 4
+halofit_version = 9
 
 #Baryonic feedback temperature if using HMcode-2020 with feedback
 #HMcode_logT_AGN = 7.8


### PR DESCRIPTION
This simple pull request changes the default non-linear model in CAMB to HMcode (2020), the paper of which has recently been accepted for publication. (So HMcode 2021 maybe... too bad).

The updated version of the paper will appear on arXiv next week. It contains a new appendix D in which HMcode (2020) is compared to 6 different emulators for 100 uniform-random cosmological parameters that are drawn from each emulator parameter space individually (so the cosmologies drawn are different for each emulator, since each emulates over different ranges and choices of cosmological parameters).

![image](https://user-images.githubusercontent.com/9140961/104034505-ddb70400-51c8-11eb-9c22-82c50474b52d.png)

The above is a copy of the Figure from the new version of the paper. The black line shows the mean across the cosmological models while the blue-shaded regions showing percentiles in 20% intervals. Based on this you can see that the new HMcode does a pretty good job for these random cosmologies drawn from each emulator, and it's applicability isn't restricted to the FrankenEmu cosmologies on which it was trained. The vertical dashed line shows the k limit quoted for each different emulation scheme, while the dashed horizontal lines show the expected agreement between HMcode and the emulator assuming that the error of HMcode (2.5%) and that of the emulator can be added in quadrature. Note that this figure is at z=0, but the figure looks quite similar at other z.

![image](https://user-images.githubusercontent.com/9140961/104035021-8d8c7180-51c9-11eb-8e54-9587e6950582.png)
![image](https://user-images.githubusercontent.com/9140961/104035785-726e3180-51ca-11eb-8e17-fe6c26984263.png)

The above two figures show the same style of comparison, but for the HMcode (2016) version (previous default; top) and for the Takahashi et al. (2012) HALOFIT (as implemented in CAMB; bottom). From these figures, I am confident in saying that HMcode (2020) is better than these alternative non-linear models, both in that the mean is more accurate and that the dispersion about this mean is less.
