### PR TITLE
Memory check to prevent very rare nested sampling segfault

### DIFF
--- a/fortran/cmbmain.f90
+++ b/fortran/cmbmain.f90
@@ -731,6 +731,7 @@
     end subroutine DoSourcek
 
     subroutine GetSourceMem
+    integer :: err
 
     if (CP%WantScalars) then
         if (WantLateTime) then
@@ -752,7 +753,8 @@
     if (allocated(ThisSources%LinearSrc)) &
         deallocate(ThisSources%LinearSrc)
     allocate(ThisSources%LinearSrc(ThisSources%Evolve_q%npoints,&
-        ThisSources%SourceNum,State%TimeSteps%npoints), source=0._dl)
+        ThisSources%SourceNum,State%TimeSteps%npoints), source=0._dl, stat=err)
+    if (err/=0) call GlobalError('Sources requires too much memory to allocate', error_unsupported_params)                                                                               
 
     end subroutine GetSourceMem
 


### PR DESCRIPTION
I have managed to track down an error which I have found occurs for a few models in
rare ~O(10^-5) cases when nested sampling. It occurs in `cmbmain.f90` an
allocation in GetSourceMem. For unusual parameter values this can cause
segfault when it tries to allocate more memory than is available. This is
easily prevented by simply passing `stat` to check if an error is raised, and
if so calling `GlobalError`. This PR implements this, and I have yet to see it
resurface.

The only thing I'm not certain of in this PR is whether
`error_unsupported_params` is the most appropriate one to raise in this
instance.
