### PR TITLE
Raise error if dark energy set_w_a_table is called for a<=0

### DIFF
--- a/camb/dark_energy.py
+++ b/camb/dark_energy.py
@@ -67,6 +67,8 @@ class DarkEnergyEqnOfState(DarkEnergyModel):
             raise ValueError('Dark energy w(a) table non-equal sized arrays')
         if not np.isclose(a[-1], 1):
             raise ValueError('Dark energy w(a) arrays must end at a=1')
+        if np.any(a <= 0):
+            raise ValueError('Dark energy w(a) table cannot be set for a<=0')
 
         a = a.astype("double")
         w = w.astype("double")

--- a/camb/dark_energy.py
+++ b/camb/dark_energy.py
@@ -68,6 +68,9 @@ class DarkEnergyEqnOfState(DarkEnergyModel):
         if not np.isclose(a[-1], 1):
             raise ValueError('Dark energy w(a) arrays must end at a=1')
 
+        a = a.astype("double")
+        w = w.astype("double")
+
         self.f_SetWTable(a, w, byref(c_int(len(a))))
         return self
 

--- a/camb/dark_energy.py
+++ b/camb/dark_energy.py
@@ -70,8 +70,8 @@ class DarkEnergyEqnOfState(DarkEnergyModel):
         if np.any(a <= 0):
             raise ValueError('Dark energy w(a) table cannot be set for a<=0')
 
-        a = a.astype("double")
-        w = w.astype("double")
+        a = np.ascontiguousarray(a, dtype=np.float64)
+        w = np.ascontiguousarray(w, dtype=np.float64)
 
         self.f_SetWTable(a, w, byref(c_int(len(a))))
         return self


### PR DESCRIPTION
set_w_a_table() raises an error if provided with 0 or negative values of a, as I have found this causes problems e.g. power_spectra_from_transfer() just hangs.

The a and w arrays are also cast to double, primarily to allow w to be set to an array of -1 (rather than -1.0) without problems.