### PR TITLE
Rename nonlinear -> NonLinear in CAMBparams

### DIFF
--- a/camb/model.py
+++ b/camb/model.py
@@ -657,7 +657,7 @@ class CAMBparams(F2003Class):
         except AttributeError:
             raise CAMBError('Not able to compute DH: not using an interpolation table for BBN abundances.')
 
-    def set_matter_power(self, redshifts=(0.,), kmax=1.2, k_per_logint=None, nonlinear=None,
+    def set_matter_power(self, redshifts=(0.,), kmax=1.2, k_per_logint=None, NonLinear=None,
                          accurate_massive_neutrino_transfers=False, silent=False):
         """
         Set parameters for calculating matter power spectra and transfer functions.
@@ -665,7 +665,7 @@ class CAMBparams(F2003Class):
         :param redshifts: array of redshifts to calculate
         :param kmax: maximum k to calculate (where k is just k, not k/h)
         :param k_per_logint: minimum number of k steps per log k. Set to zero to use default optimized spacing.
-        :param nonlinear: if None, uses existing setting, otherwise boolean for whether to use non-linear matter power.
+        :param NonLinear: if None, uses existing setting, otherwise boolean for whether to use non-linear matter power.
         :param accurate_massive_neutrino_transfers: if you want the massive neutrino transfers accurately
         :param silent: if True, don't give warnings about sort order
         :return: self
@@ -678,8 +678,8 @@ class CAMBparams(F2003Class):
         self.Transfer.accurate_massive_neutrinos = accurate_massive_neutrino_transfers
         self.Transfer.kmax = kmax
         zs = sorted(redshifts, reverse=True)
-        if nonlinear is not None:
-            if nonlinear:
+        if NonLinear is not None:
+            if NonLinear:
                 if self.NonLinear in [NonLinear_lens, NonLinear_both]:
                     self.NonLinear = NonLinear_both
                 else:
@@ -699,14 +699,14 @@ class CAMBparams(F2003Class):
         self.Transfer.PK_redshifts = zs
         return self
 
-    def set_nonlinear_lensing(self, nonlinear):
+    def set_nonlinear_lensing(self, NonLinear):
         """
         Settings for whether or not to use non-linear corrections for the CMB lensing potential.
         Note that set_for_lmax also sets lensing to be non-linear if lens_potential_accuracy>0
 
-        :param nonlinear: true to use non-linear corrections
+        :param NonLinear: true to use non-linear corrections
         """
-        if nonlinear:
+        if NonLinear:
             if self.NonLinear in [NonLinear_pk, NonLinear_both]:
                 self.NonLinear = NonLinear_both
             else:
@@ -718,7 +718,7 @@ class CAMBparams(F2003Class):
                 self.NonLinear = NonLinear_none
 
     def set_for_lmax(self, lmax, max_eta_k=None, lens_potential_accuracy=0,
-                     lens_margin=150, k_eta_fac=2.5, lens_k_eta_reference=18000.0, nonlinear=None):
+                     lens_margin=150, k_eta_fac=2.5, lens_k_eta_reference=18000.0, NonLinear=None):
         r"""
         Set parameters to get CMB power spectra accurate to specific a l_lmax.
         Note this does not fix the actual output L range, spectra may be calculated above l_max
@@ -735,7 +735,7 @@ class CAMBparams(F2003Class):
         :param k_eta_fac:  k_eta_fac default factor for setting max_eta_k = k_eta_fac*lmax if max_eta_k=None
         :param lens_k_eta_reference:  value of max_eta_k to use when lens_potential_accuracy>0; use
                                       k_eta_max = lens_k_eta_reference*lens_potential_accuracy
-        :param nonlinear: use non-linear power spectrum; if None, sets nonlinear if lens_potential_accuracy>0 otherwise
+        :param NonLinear: use non-linear power spectrum; if None, sets NonLinear if lens_potential_accuracy>0 otherwise
                           preserves current setting
         :return: self
         """
@@ -745,10 +745,10 @@ class CAMBparams(F2003Class):
             self.max_l = lmax
         self.max_eta_k = max_eta_k or self.max_l * k_eta_fac
         if lens_potential_accuracy:
-            self.set_nonlinear_lensing(nonlinear is not False)
+            self.set_nonlinear_lensing(NonLinear is not False)
             self.max_eta_k = max(self.max_eta_k, lens_k_eta_reference * lens_potential_accuracy)
-        elif nonlinear is not None:
-            self.set_nonlinear_lensing(nonlinear)
+        elif NonLinear is not None:
+            self.set_nonlinear_lensing(NonLinear)
         return self
 
     def scalar_power(self, k):

--- a/camb/tests/camb_test.py
+++ b/camb/tests/camb_test.py
@@ -308,9 +308,9 @@ class CambTest(unittest.TestCase):
         self.assertAlmostEqual(pars.scalar_power(1), 1.801e-9, 4)
         self.assertAlmostEqual(pars.scalar_power([1, 1.5])[0], 1.801e-9, 4)
 
-        pars.set_matter_power(nonlinear=True)
+        pars.set_matter_power(NonLinear=True)
         self.assertEqual(pars.NonLinear, model.NonLinear_pk)
-        pars.set_matter_power(redshifts=[0., 0.17, 3.1], silent=True, nonlinear=False)
+        pars.set_matter_power(redshifts=[0., 0.17, 3.1], silent=True, NonLinear=False)
         data = camb.get_results(pars)
 
         kh, z, pk = data.get_matter_power_spectrum(1e-4, 1, 20)
@@ -450,13 +450,13 @@ class CambTest(unittest.TestCase):
         pars = camb.CAMBparams()
         pars.set_cosmology(H0=67.5, ombh2=0.022, omch2=0.122, mnu=0.07, omk=0)
         pars.InitPower.set_params(ns=0.965, As=2e-9)
-        pars.set_matter_power(nonlinear=False)
+        pars.set_matter_power(NonLinear=False)
         results = camb.get_results(pars)
         sigma8 = results.get_sigma8_0()
         self.assertAlmostEqual(sigma8, results.get_sigmaR(8)[-1], places=3)
         self.assertAlmostEqual(sigma8, results.get_sigmaR(np.array([8]), z_indices=-1)[-1], places=3)
         self.assertAlmostEqual(results.get_sigmaR(8)[-1], results.get_sigmaR(8, z_indices=-1))
-        pars.set_matter_power(nonlinear=False, k_per_logint=0, kmax=2)
+        pars.set_matter_power(NonLinear=False, k_per_logint=0, kmax=2)
         results = camb.get_results(pars)
         P, z, k = results.get_matter_power_interpolator(nonlinear=False, hubble_units=False, k_hunit=False,
                                                         return_z_k=True, extrap_kmax=100, silent=True)
@@ -482,7 +482,7 @@ class CambTest(unittest.TestCase):
         self.assertAlmostEqual(py_sigma2, truth, places=3)
         self.assertTrue(abs(results.get_sigmaR(8)[-1] / truth - 1) < 1e-4)
         self.assertTrue(abs(results.get_sigmaR(np.array([8]), z_indices=-1)[-1] / truth - 1) < 1e-4)
-        pars.set_matter_power(nonlinear=False, k_per_logint=0, kmax=1.2, redshifts=np.arange(0, 10, 2))
+        pars.set_matter_power(NonLinear=False, k_per_logint=0, kmax=1.2, redshifts=np.arange(0, 10, 2))
         results = camb.get_results(pars)
         sigmas = results.get_sigmaR(np.arange(1, 20, 1), hubble_units=False, z_indices=None)
         pars.Accuracy.AccuracyBoost = 2
@@ -490,7 +490,7 @@ class CambTest(unittest.TestCase):
         sigmas2 = results.get_sigmaR(np.arange(1, 20, 1), hubble_units=False, z_indices=None)
         self.assertTrue(np.all(np.abs(sigmas / sigmas2 - 1) < 1e-3))
         pars.Accuracy.AccuracyBoost = 1
-        pars.set_matter_power(nonlinear=False, k_per_logint=100, kmax=10, redshifts=np.arange(0, 10, 2))
+        pars.set_matter_power(NonLinear=False, k_per_logint=100, kmax=10, redshifts=np.arange(0, 10, 2))
         results = camb.get_results(pars)
         sigmas2 = results.get_sigmaR(np.arange(1, 20, 1), hubble_units=False, z_indices=None)
         self.assertAlmostEqual(sigmas2[4, 2], 1.77346, places=3)


### PR DESCRIPTION
Attempt to fix the inconsistent use of CamelCase with the NonLinear field of CAMBparams.

I noticed this as the docs use NonLinear as they read the name from \_fields\_, but nonlinear is used in the interface. I've switched it to NonLinear.
