### PR TITLE
Fix dark energy fluid crossing -1 comment

### DIFF
--- a/camb/dark_energy.py
+++ b/camb/dark_energy.py
@@ -100,7 +100,7 @@ class DarkEnergyFluid(DarkEnergyEqnOfState):
                 raise CAMBError('fluid dark energy model does not support w crossing -1')
 
     def set_w_a_table(self, a, w):
-        # check w array has elements that are all the same sign or zero
+        # check w array has elements that do not cross -1
         if np.sign(1 + np.max(w)) - np.sign(1 + np.min(w)) == 2:
             raise ValueError('fluid dark energy model does not support w crossing -1')
         super().set_w_a_table(a, w)


### PR DESCRIPTION
I think this comment in `DarkEnergyFluid.set_w_a_table()` should say that all the w array elements shouldn't cross -1, not that they're all the same sign.