### PR TITLE
Added parameter to control max reionization z externally

### DIFF
--- a/camb/reionization.py
+++ b/camb/reionization.py
@@ -75,6 +75,15 @@ class BaseTauWithHeReionization(ReionizationModel):
         self.optical_depth = tau
         return self
 
+    def set_extra_params(self, max_zrei=None):
+        """
+        Set extra parameters (not tau, or zrei)
+
+        :param max_zrei: maximum redshift allowed when mapping tau into reionization redshift
+        """
+        if max_zrei is not None:
+            self.max_redshift = max_zrei
+
 
 @fortran_class
 class TanhReionization(BaseTauWithHeReionization):
@@ -87,12 +96,14 @@ class TanhReionization(BaseTauWithHeReionization):
 
     _fortran_class_name_ = 'TTanhReionization'
 
-    def set_extra_params(self, deltazrei=None):
+    def set_extra_params(self, deltazrei=None, max_zrei=None):
         """
         Set extra parameters (not tau, or zrei)
 
         :param deltazrei: delta z for reionization
+        :param max_zrei: maximum redshift allowed when mapping tau into reionization
         """
+        super().set_extra_params(max_zrei)
         if deltazrei is not None:
             self.delta_redshift = deltazrei
 
@@ -111,15 +122,16 @@ class ExpReionization(BaseTauWithHeReionization):
 
     _fortran_class_name_ = 'TExpReionization'
 
-    def set_extra_params(self, reion_redshift_complete=None, reion_exp_power=None, reion_exp_smooth_width=None):
+    def set_extra_params(self, reion_redshift_complete=None, reion_exp_power=None, reion_exp_smooth_width=None, max_zrei=None):
         """
         Set extra parameters (not tau, or zrei)
 
         :param reion_redshift_complete: redshift at which reionization complete (e.g. around 6)
         :param reion_exp_power: power in exponential decay with redshift
         :param reion_exp_smooth_width: smoothing parameter to keep derivative smooth
+        :param max_zrei: maximum redshift allowed when mapping tau into reionization
         """
-
+        super().set_extra_params(max_zrei)
         if reion_redshift_complete is not None:
             self.reion_redshift_complete = reion_redshift_complete
         if reion_exp_power is not None:

--- a/camb/tests/camb_test.py
+++ b/camb/tests/camb_test.py
@@ -93,7 +93,7 @@ class CambTest(unittest.TestCase):
         self.assertEqual(params, {'ombh2', 'deltazrei', 'omnuh2', 'tau', 'omk', 'zrei', 'thetastar', 'nrunrun',
                                   'meffsterile', 'nnu', 'ntrun', 'HMCode_A_baryon', 'HMCode_eta_baryon',
                                   'HMCode_logT_AGN', 'cosmomc_theta', 'YHe', 'wa', 'cs2', 'H0', 'mnu', 'Alens',
-                                  'TCMB', 'ns', 'nrun', 'As', 'nt', 'r', 'w', 'omch2'})
+                                  'TCMB', 'ns', 'nrun', 'As', 'nt', 'r', 'w', 'omch2', 'max_zrei'})
         params2 = camb.get_valid_numerical_params(dark_energy_model='AxionEffectiveFluid')
         self.assertEqual(params2.difference(params), {'fde_zc', 'w_n', 'zc', 'theta_i'})
 


### PR DESCRIPTION
This small change allows to set max reionization redshift from cobaya - avoiding the annoying "Did not converge to optical depth" error.

max z effectively sets an implicit prior on tau so it is useful to control it.