### PR TITLE
Update typing syntax to Python 3.10 standards

### DIFF
--- a/camb/bbn.py
+++ b/camb/bbn.py
@@ -187,7 +187,7 @@ class BBN_fitting_parthenope(BBNPredictor):
         ) * pow((tau_neutron or self.taun) / 880.3, 0.418) * 1e-5
 
 
-_predictors = {}
+_predictors: dict[str, BBNPredictor] = {}
 
 
 def get_predictor(predictor_name=None):

--- a/camb/correlations.py
+++ b/camb/correlations.py
@@ -22,7 +22,7 @@ except:
     # Fortran version is much faster than current np.polynomial
     gauss_legendre = None
 
-_gauss_legendre_cache = {}
+_gauss_legendre_cache: dict[int, tuple[np.ndarray, np.ndarray]] = {}
 
 
 def _cached_gauss_legendre(npoints, cache=True):

--- a/camb/model.py
+++ b/camb/model.py
@@ -14,7 +14,7 @@ from .reionization import ReionizationModel
 from .sources import SourceWindow
 from . import bbn
 import logging
-from typing import Union, Optional
+# Union and Optional types are now built-in to Python 3.10+
 
 max_nu = 5
 max_transfer_redshifts = 256
@@ -431,13 +431,13 @@ class CAMBparams(F2003Class):
         except ValueError:
             raise CAMBParamRangeError('No solution for H0 inside of theta_H0_range')
 
-    def set_cosmology(self, H0: Optional[float] = None, ombh2=0.022, omch2=0.12, omk=0.0,
-                      cosmomc_theta: Optional[float] = None, thetastar: Optional[float] = None,
-                      neutrino_hierarchy: Union[str, int] = 'degenerate', num_massive_neutrinos=1,
-                      mnu=0.06, nnu=constants.default_nnu, YHe: Optional[float] = None, meffsterile=0.0,
+    def set_cosmology(self, H0: float | None = None, ombh2=0.022, omch2=0.12, omk=0.0,
+                      cosmomc_theta: float | None = None, thetastar: float | None = None,
+                      neutrino_hierarchy: str | int = 'degenerate', num_massive_neutrinos=1,
+                      mnu=0.06, nnu=constants.default_nnu, YHe: float | None = None, meffsterile=0.0,
                       standard_neutrino_neff=constants.default_nnu, TCMB=constants.COBE_CMBTemp,
-                      tau: Optional[float] = None, zrei: Optional[float] = None,
-                      Alens=1.0, bbn_predictor: Union[None, str, bbn.BBNPredictor] = None,
+                      tau: float | None = None, zrei: float | None = None,
+                      Alens=1.0, bbn_predictor: None | str | bbn.BBNPredictor = None,
                       theta_H0_range=(10, 100), setter_H0=None):
         r"""
         Sets cosmological parameters in terms of physical densities and parameters (e.g. as used in Planck analyses).
@@ -811,7 +811,7 @@ class CAMBparams(F2003Class):
         else:
             return powers
 
-    _custom_source_name_dict = {}
+    _custom_source_name_dict: dict[int, str] = {}
 
     def set_custom_scalar_sources(self, custom_sources, source_names=None, source_ell_scales=None,
                                   frame='CDM', code_path=None):

--- a/camb/symbolic.py
+++ b/camb/symbolic.py
@@ -17,6 +17,7 @@ A Lewis July 2017
 import ctypes
 import os
 import sympy
+from typing import Any
 from sympy import diff, Eq, simplify, Function, Symbol
 from sympy.core.relational import Relational
 from sympy.abc import t, kappa, K, k
@@ -294,7 +295,7 @@ def constraint_subs_for_variable_set(variables=(z, sigma, phi, hdot)):
 
 var_subs = constraint_subs_for_variable_set()
 
-hdot_sub, phi_sub, sigma_sub, z_sub = [Eq(variable, subs(var_subs, variable)) for variable in [hdot, phi, sigma, z]]
+hdot_sub, phi_sub, sigma_sub, z_sub = (Eq(variable, subs(var_subs, variable)) for variable in [hdot, phi, sigma, z])
 q_sub = Eq(q, subs(Eq(z, subs(var_subs, z)), solve(cons3, q)))
 
 # Evolution equations
@@ -609,7 +610,7 @@ def get_scalar_temperature_sources(checks=False):
 
 
 # for translation in source output routine (does not include all equation variables)
-_camb_cache = {}
+_camb_cache: dict[str, Any] = {}
 
 
 def camb_fortran(expr, name='camb_function', frame='CDM', expand=False):
@@ -705,7 +706,7 @@ def camb_fortran(expr, name='camb_function', frame='CDM', expand=False):
     return res
 
 
-_func_cache = {}
+_func_cache: dict[str, Any] = {}
 _source_file_count = 0
 
 _default_compiler = None


### PR DESCRIPTION
This PR updates the typing syntax in the Python code to Python 3.10 standards:

- Replaces `Optional[Type]` with `Type | None`
- Replaces `Union[Type1, Type2]` with `Type1 | Type2`
- Adds proper type annotations for dictionary variables
- Adds type annotation for array variable
- Removes unnecessary imports from typing module

Next step would be to check with pyright for more comprehensive type checking.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author