### PR TITLE
Fix data race in OMP PARALLEL SECTIONS for derived thermo parameters

### DIFF
--- a/fortran/results.f90
+++ b/fortran/results.f90
@@ -2170,26 +2170,25 @@
 
     if (CP%WantDerivedParameters) then
         associate(ThermoDerivedParams => State%ThermoDerivedParams)
-            !$OMP PARALLEL SECTIONS DEFAULT(SHARED)
-            !$OMP SECTION
+            ! Not run as OMP PARALLEL SECTIONS: these calls share mutable state on State/this
+            ! (background/spline lookups used by sound_horizon, DeltaPhysicalTimeGyr, dtauda,
+            ! timeOfz, Integrate_Romberg), so running them concurrently is a data race that
+            ! silently corrupts the derived parameters below (reproduced with ifx; not caught
+            ! by gfortran, which doesn't make it safe, just not observed).
             ThermoDerivedParams( derived_Age ) = State%DeltaPhysicalTimeGyr(0.0_dl,1.0_dl)
             rstar =State%sound_horizon(this%z_star)
             ThermoDerivedParams( derived_rstar ) = rstar
             DA = State%AngularDiameterDistance(this%z_star)/(1/(this%z_star+1))
             ThermoDerivedParams( derived_zdrag ) = this%z_drag
-            !$OMP SECTION
             rs =State%sound_horizon(this%z_drag)
             ThermoDerivedParams( derived_rdrag ) = rs
             ThermoDerivedParams( derived_kD ) =  &
                 sqrt(1.d0/(Integrate_Romberg(State,ddamping_da, 1d-8, 1/(this%z_star+1), 1d-6)/6))
-            !$OMP SECTION
             ThermoDerivedParams( derived_zEQ ) = State%z_eq
             a_eq = 1/(1+State%z_eq)
             ThermoDerivedParams( derived_kEQ ) = 1/(a_eq*dtauda(State,a_eq))
             rs_eq = State%sound_horizon(State%z_eq)
             tau_eq = State%timeOfz(State%z_eq)
-            !$OMP SECTION
-            !$OMP END PARALLEL SECTIONS
 
             ThermoDerivedParams( derived_zstar ) = this%z_star
             ThermoDerivedParams( derived_thetastar ) = 100*rstar/DA


### PR DESCRIPTION
## Summary

The `!$OMP PARALLEL SECTIONS` block in `CAMBdata_GetDerivedParams` (`fortran/results.f90`) that computes derived thermodynamic parameters (age of universe, sound horizon, drag redshift, z_eq, k_eq, etc.) runs three sections concurrently that all call numerical routines (`sound_horizon`, `DeltaPhysicalTimeGyr`, `dtauda`, `timeOfz`, `Integrate_Romberg`) on the *same* shared `State`/`this` object. These calls share mutable state (most likely a cached interpolation/lookup index used internally by the background-evolution splines). Running them concurrently is a genuine data race, and with `OMP_NUM_THREADS > 1` it silently produces **wrong derived parameters** — no crash, no warning a user would necessarily notice.

Reproduced with ifx 2026.1.0 and ifx 2025.2.1 (`-O3 -xHost -qopenmp`, with and without `-ipo`). Not observed with gfortran 13.3.0 in this testing, but that reflects codegen/scheduling luck, not a safe underlying construct — the same shared object is genuinely mutated concurrently by construction, independent of compiler.

## Impact

Any user running the Fortran `camb` binary built with ifx, with `OMP_NUM_THREADS` (or the default, which uses all cores) greater than 1 and `WantDerivedParameters=T` (the default), can get silently wrong derived parameters — e.g. age of the universe reported as 46.8 Gyr or as a formatted-field overflow (`*******`) instead of the correct 13.777 Gyr for Planck-like parameters. `theta_rs_EQ` and other derived quantities are similarly corrupted, non-deterministically, since it's a genuine race rather than a deterministic bug.

## Reproduction

Built from `master` @ b062e82, using `fortran/inifiles/params.ini`:

```
cd fortran
make camb F90C=ifx AR=llvm-ar AREXE=llvm-ar \
  FFLAGS="-fpp -qopenmp -fp-model precise -W0 -WB -O3 -xHost" \
  F90RELEASEFLAGS="-fpp -W0 -WB -qopenmp -O3 -xHost"
# (llvm-ar needed because ifx emits LLVM-bitcode objects that GNU ar/ld
#  can't read - unrelated to the race itself)

OMP_NUM_THREADS=1  ./camb params.ini | grep "Age of universe"   # 13.777 (correct)
OMP_NUM_THREADS=2  ./camb params.ini | grep "Age of universe"   # 46.840 (wrong)
OMP_NUM_THREADS=6  ./camb params.ini | grep "Age of universe"   # varies: wrong or overflow
OMP_NUM_THREADS=20 ./camb params.ini | grep "Age of universe"   # varies: wrong or overflow
```

Correctness sweep (5 repeats per thread count) on unmodified `master`:

| threads | correct / 5 |
|---|---|
| 1  | 5/5 |
| 2  | 0/5 |
| 4  | 0/5 |
| 6  | 0/5 (2 also printed "Integrate_Romberg failed to converge") |
| 12 | 0/5 |
| 20 | 1/5 |

Same sweep with only the `!$OMP PARALLEL SECTIONS`/`!$OMP SECTION`/`!$OMP END PARALLEL SECTIONS` directives around this block removed (everything else, including all other `!$OMP PARALLEL DO` regions, untouched):

| threads | correct / 5 |
|---|---|
| 1  | 5/5 |
| 2  | 5/5 |
| 4  | 5/5 |
| 6  | 5/5 |
| 12 | 5/5 |
| 20 | 5/5 |

This isolates the race to this exact block. A leftover, non-corrupting "Integrate_Romberg failed to converge" warning still appears occasionally with this block serialized, suggesting `Integrate_Romberg` may also be called concurrently from other `!$OMP PARALLEL DO` regions elsewhere (e.g. `cmbmain.f90`/`equations.f90`) — not investigated further, seems lower-impact since it didn't corrupt output in this testing.

Ruled out: static (rather than stack) storage for locals in `Integrate_Romberg` (`MathUtils.f90`) — rebuilding with `-recursive` (forces automatic/stack allocation for all locals) did not fix the race, so the shared mutable state is elsewhere, most likely a cached/mutable field on `State`/`this` used internally by the background spline evaluation routines. Not root-caused further.

## Fix

Serialize this block. It computes a handful of scalar integrals once per run (negligible cost) — no measurable performance difference from removing the parallelism (benchmarked before/after on both gfortran and ifx, single- and multi-threaded, difference is within run-to-run noise, ~1-5%).

## Related history

This exact block has a prior Intel-compiler-specific issue: #80 (merged) fixed an ifort19 segfault here (allocatable array not visible inside the OMP section without explicit `shared`), which is why `DEFAULT(SHARED)` is already present. That fix addressed a different symptom and predates the data race described here. #81 (not merged) separately proposed disabling OMP in this area for debug-mode traceback support, so serializing this specific block has precedent as an accepted style of fix.

## Environment

- Compilers: ifx (IFX) 2026.1.0 20260617; ifx (IFX) 2025.2.1 20250806 (same result on both); gfortran 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)
- OS: Ubuntu 24.04.4 LTS
- CPU: Intel Core i5-14500 (6 P-cores/HT + 8 E-cores, 20 logical CPUs)

---
Guided-by / co-authored-by Mauricio Calvao (@mocalvao).
