### PR TITLE
Avoid unavailable static OpenMP runtime on macOS

### DIFF
--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -105,8 +105,14 @@ DEBUGFLAGS = -g -fbacktrace -ffpe-trap=invalid,overflow,zero -fbounds-check $(CO
 ifeq ($(shell uname -s),Darwin)
 SFFLAGS = -dynamiclib #-fpic
 ifneq ($(shell echo $(compiler_ver) | awk '{print ($$1 >= 14.0)}'),0)
+# Static runtimes help isolate the Python extension from differently compiled
+# libraries loaded into the same process. Only request them when the complete
+# static runtime needed by this OpenMP build is available.
 LIBGFORTRAN_A := $(shell $(F90C) -print-file-name=libgfortran.a)
-ifneq ($(shell [ -f "$(LIBGFORTRAN_A)" ] && echo yes),)
+LIBQUADMATH_A := $(shell $(F90C) -print-file-name=libquadmath.a)
+LIBGCC_A := $(shell $(F90C) -print-file-name=libgcc.a)
+LIBGOMP_A := $(shell $(F90C) -print-file-name=libgomp.a)
+ifneq ($(shell [ -f "$(LIBGFORTRAN_A)" ] && [ -f "$(LIBQUADMATH_A)" ] && [ -f "$(LIBGCC_A)" ] && [ -f "$(LIBGOMP_A)" ] && echo yes),)
 SFFLAGS += -static-libgfortran -static-libquadmath -static-libgcc
 endif
 endif


### PR DESCRIPTION
## Summary

Keep the existing macOS static-runtime behavior for gfortran when the complete static runtime is available, but fall back to dynamic linkage otherwise.

This preserves the reason for the existing static linkage (isolating the Python extension from differently compiled libraries loaded into the same process) while allowing toolchains that intentionally do not provide a static OpenMP runtime to build successfully.

## Motivation

conda-forge/camb-feedstock#76 currently fails on macOS with the GCC 15 gfortran toolchain at the final `camblib.so` link:

```
ld: file not found: libgomp.a
collect2: error: ld returned 1 exit status
```

The current Makefile only checks for `libgfortran.a` before adding:

```
-static-libgfortran -static-libquadmath -static-libgcc
```

With `-fopenmp`, that is not sufficient: conda-forge's macOS GCC 15 toolchain uses `libomp` for compatibility with the clang ecosystem and does not provide the required static `libgomp.a`.

## Change

Before requesting static runtime linkage, check that all static libraries needed by this OpenMP build are actually present:

- `libgfortran.a`
- `libquadmath.a`
- `libgcc.a`
- `libgomp.a`

If any are absent, CAMB keeps the normal dynamic `-dynamiclib` linkage instead.

This should retain the current standalone/wheel behavior on toolchains that support the full static runtime, while fixing the conda-forge GCC 15/macOS case.